### PR TITLE
🧹 Remove dead field `rp_origin` in `PasskeyAuth`

### DIFF
--- a/rullst/src/auth/passkey.rs
+++ b/rullst/src/auth/passkey.rs
@@ -54,8 +54,6 @@ impl PasskeyConfig {
 pub struct PasskeyAuth {
     rp_name: String,
     rp_id: String,
-    #[allow(dead_code)]
-    rp_origin: String,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
@@ -297,7 +295,6 @@ impl PasskeyAuth {
         Ok(Self {
             rp_name: config.rp_name.clone(),
             rp_id: config.rp_id.clone(),
-            rp_origin: config.rp_origin.clone(),
         })
     }
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `rp_origin` field from the `PasskeyAuth` struct in `src/auth/passkey.rs`. Also removed the associated `#[allow(dead_code)]` annotation and the initialization logic in `PasskeyAuth::new`.
💡 **Why:** This improves maintainability and cleans up the struct, reducing memory overhead, as the field was already marked as unused code.
✅ **Verification:** Ran `cargo check` and `cargo test`. All tests passed, confirming no functionality was broken.
✨ **Result:** Improved code health and cleaner struct definition without breaking functionality.

---
*PR created automatically by Jules for task [16928788849050150873](https://jules.google.com/task/16928788849050150873) started by @venelouis*