### PR TITLE
🧹 [code health] Remove unused `TestResponse::new` method

### DIFF
--- a/rullst/src/testing.rs
+++ b/rullst/src/testing.rs
@@ -179,11 +179,6 @@ pub struct TestResponse {
 }
 
 impl TestResponse {
-    #[allow(dead_code)]
-    pub(crate) async fn new(response: Response) -> Self {
-        Self::new_with_limit(response, DEFAULT_MAX_BODY).await
-    }
-
     pub(crate) async fn new_with_limit(response: Response, max_body_bytes: usize) -> Self {
         let (parts, body) = response.into_parts();
         let body_bytes = to_bytes(body, max_body_bytes)


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was dead code, specifically the `TestResponse::new` method in `rullst/src/testing.rs` which was unused and flagged with `#[allow(dead_code)]`.
💡 **Why:** This improves maintainability by removing unnecessary code and the associated attribute, which cleans up the file and reduces mental overhead for developers reading the file.
✅ **Verification:** I confirmed the change is safe by running `cargo check` and `cargo test`, which passed with no regressions.
✨ **Result:** The codebase is now cleaner without dead code and the test suite remains unaffected.

---
*PR created automatically by Jules for task [13813404297667349915](https://jules.google.com/task/13813404297667349915) started by @venelouis*