### PR TITLE
🧪 Add test coverage for `list_all_jobs` in `queue.rs`

### DIFF
--- a/rullst/src/queue.rs
+++ b/rullst/src/queue.rs
@@ -675,6 +675,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_sqlite_queue_list_all_jobs() {
+        let driver = SqliteDriver::new("sqlite::memory:").await.unwrap();
+
+        // 1. Test empty queue
+        let jobs = driver.list_all_jobs(10).await.unwrap();
+        assert!(jobs.is_empty(), "Expected empty jobs list initially");
+
+        // 2. Populate queue and test limit
+        driver
+            .push("job-1", "job_type_a", r#"{"data": 1}"#)
+            .await
+            .unwrap();
+        driver
+            .push("job-2", "job_type_b", r#"{"data": 2}"#)
+            .await
+            .unwrap();
+        driver
+            .push("job-3", "job_type_c", r#"{"data": 3}"#)
+            .await
+            .unwrap();
+
+        // Check if all 3 jobs are returned when limit is large enough
+        let all_jobs = driver.list_all_jobs(10).await.unwrap();
+        assert_eq!(all_jobs.len(), 3, "Expected 3 jobs");
+
+        // SQLite order: "ORDER BY created_at DESC"
+        // Since we insert them back-to-back, sometimes they have the exact same created_at
+        // so we'll just check that they are all present
+        assert!(all_jobs.iter().any(|j| j.id == "job-1"));
+        assert!(all_jobs.iter().any(|j| j.id == "job-2"));
+        assert!(all_jobs.iter().any(|j| j.id == "job-3"));
+
+        // Test limit
+        let limited_jobs = driver.list_all_jobs(2).await.unwrap();
+        assert_eq!(limited_jobs.len(), 2, "Expected exactly 2 jobs due to limit");
+
+        // 3. Test Err path
+        // To trigger an error, we can close the connection pool and then attempt to query.
+        driver.pool.close().await;
+
+        let result = driver.list_all_jobs(10).await;
+        assert!(result.is_err(), "Expected error after pool is closed");
+        match result {
+            Err(QueueError::Driver(msg)) => {
+                assert!(msg.contains("pool timed out") || msg.contains("closed"), "Unexpected error message: {}", msg);
+            }
+            _ => panic!("Expected QueueError::Driver"),
+        }
+    }
+
+    #[tokio::test]
     async fn test_custom_queue_driver() {
         // Since we need to check was_push_called, we'll share state via Arc.
         let push_called = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));

--- a/rullst/src/queue.rs
+++ b/rullst/src/queue.rs
@@ -709,7 +709,11 @@ mod tests {
 
         // Test limit
         let limited_jobs = driver.list_all_jobs(2).await.unwrap();
-        assert_eq!(limited_jobs.len(), 2, "Expected exactly 2 jobs due to limit");
+        assert_eq!(
+            limited_jobs.len(),
+            2,
+            "Expected exactly 2 jobs due to limit"
+        );
 
         // 3. Test Err path
         // To trigger an error, we can close the connection pool and then attempt to query.
@@ -719,7 +723,11 @@ mod tests {
         assert!(result.is_err(), "Expected error after pool is closed");
         match result {
             Err(QueueError::Driver(msg)) => {
-                assert!(msg.contains("pool timed out") || msg.contains("closed"), "Unexpected error message: {}", msg);
+                assert!(
+                    msg.contains("pool timed out") || msg.contains("closed"),
+                    "Unexpected error message: {}",
+                    msg
+                );
             }
             _ => panic!("Expected QueueError::Driver"),
         }

--- a/test_plan.sh
+++ b/test_plan.sh
@@ -1,0 +1,1 @@
+cargo test test_sqlite_queue_list_all_jobs


### PR DESCRIPTION
🎯 **What:** Added missing test coverage for `SqliteDriver::list_all_jobs` in `rullst/src/queue.rs`.
📊 **Coverage:** The new test, `test_sqlite_queue_list_all_jobs`, covers empty queue scenarios, populated queue with limit constraints, and simulates a failure by closing the connection pool to test the error path. 
✨ **Result:** Increased testing coverage and confidence that the `list_all_jobs` functionality behaves correctly under expected and unexpected conditions.

---
*PR created automatically by Jules for task [692413055615418709](https://jules.google.com/task/692413055615418709) started by @venelouis*