### PR TITLE
🧪 Add test for Message::to

### DIFF
--- a/rullst/src/mail.rs
+++ b/rullst/src/mail.rs
@@ -410,4 +410,10 @@ mod tests {
         assert!(content.contains("Subject: Hello Test"));
         assert!(content.contains("Testing 1 2 3"));
     }
+
+    #[test]
+    fn test_message_to() {
+        let msg = Message::new().to("user@example.com");
+        assert_eq!(msg.to, "user@example.com");
+    }
 }


### PR DESCRIPTION
🎯 **What:** The untested `to` method on the `Message` builder has been covered.
📊 **Coverage:** The happy path for correctly setting the `to` field via `Message::new().to()` is now verified.
✨ **Result:** Test coverage for the `mail.rs` module has increased, improving the reliability of the `Message` builder.

---
*PR created automatically by Jules for task [10409370976800481765](https://jules.google.com/task/10409370976800481765) started by @venelouis*