### PR TITLE
🧪 Add tests for redis queue initialization

### DIFF
--- a/rullst/src/queue.rs
+++ b/rullst/src/queue.rs
@@ -674,6 +674,27 @@ mod tests {
         assert!(result.is_none());
     }
 
+    #[test]
+    #[cfg(feature = "queue-redis")]
+    fn test_queue_redis_creation() {
+        // Happy path
+        // `redis::Client::open` does not actually connect to the server, it only parses the URL
+        let valid_result = Queue::redis("redis://127.0.0.1:6379");
+        assert!(valid_result.is_ok(), "Failed to create Redis queue with valid URL");
+
+        // Error path
+        let invalid_result = Queue::redis("invalid_url");
+        assert!(invalid_result.is_err(), "Expected error for invalid Redis URL");
+
+        match invalid_result {
+            Err(QueueError::Driver(msg)) => {
+                assert!(msg.contains("Failed to connect to Redis"), "Unexpected error message: {}", msg);
+                assert!(msg.contains("Redis URL did not parse"), "Unexpected error message details: {}", msg);
+            }
+            _ => panic!("Expected QueueError::Driver, got something else"),
+        }
+    }
+
     #[tokio::test]
     async fn test_custom_queue_driver() {
         // Since we need to check was_push_called, we'll share state via Arc.

--- a/rullst/src/queue.rs
+++ b/rullst/src/queue.rs
@@ -680,16 +680,30 @@ mod tests {
         // Happy path
         // `redis::Client::open` does not actually connect to the server, it only parses the URL
         let valid_result = Queue::redis("redis://127.0.0.1:6379");
-        assert!(valid_result.is_ok(), "Failed to create Redis queue with valid URL");
+        assert!(
+            valid_result.is_ok(),
+            "Failed to create Redis queue with valid URL"
+        );
 
         // Error path
         let invalid_result = Queue::redis("invalid_url");
-        assert!(invalid_result.is_err(), "Expected error for invalid Redis URL");
+        assert!(
+            invalid_result.is_err(),
+            "Expected error for invalid Redis URL"
+        );
 
         match invalid_result {
             Err(QueueError::Driver(msg)) => {
-                assert!(msg.contains("Failed to connect to Redis"), "Unexpected error message: {}", msg);
-                assert!(msg.contains("Redis URL did not parse"), "Unexpected error message details: {}", msg);
+                assert!(
+                    msg.contains("Failed to connect to Redis"),
+                    "Unexpected error message: {}",
+                    msg
+                );
+                assert!(
+                    msg.contains("Redis URL did not parse"),
+                    "Unexpected error message details: {}",
+                    msg
+                );
             }
             _ => panic!("Expected QueueError::Driver, got something else"),
         }


### PR DESCRIPTION
🎯 **What:** The `Queue::redis` initialization function was untested, leaving a potential gap in verification when parsing redis URLs.
📊 **Coverage:** Added a test covering both the happy path (valid redis URL) and the error path (invalid redis URL). The test runs conditionally when the `queue-redis` feature is active and ensures `QueueError::Driver` is returned when expected.
✨ **Result:** Increased test coverage in `src/queue.rs`. The new test runs safely in isolated CI environments without requiring an active redis connection.

---
*PR created automatically by Jules for task [5921700181640215129](https://jules.google.com/task/5921700181640215129) started by @venelouis*