### PR TITLE
🧪 add testing for live.rs components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,12 +77,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anes"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
-
-[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,12 +864,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cast"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
-
-[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -910,33 +898,6 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
-]
-
-[[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
 ]
 
 [[package]]
@@ -1156,42 +1117,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "criterion"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "is-terminal",
- "itertools",
- "num-traits",
- "once_cell",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
-dependencies = [
- "cast",
- "itertools",
-]
-
-[[package]]
 name = "cron"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1201,25 +1126,6 @@ dependencies = [
  "once_cell",
  "phf",
  "winnow",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1236,12 +1142,6 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -1834,17 +1734,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "zerocopy",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1892,12 +1781,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2322,30 +2205,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itoa"
@@ -2696,12 +2559,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "oorandom"
-version = "11.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2872,34 +2729,6 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
-name = "plotters"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
-dependencies = [
- "plotters-backend",
-]
 
 [[package]]
 name = "polyval"
@@ -3148,26 +2977,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "redis"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3343,9 +3152,9 @@ dependencies = [
  "chrono",
  "console_error_panic_hook",
  "cookie",
- "criterion",
  "cron",
  "dashmap",
+ "futures-util",
  "getrandom 0.2.17",
  "lettre",
  "libloading",
@@ -3363,6 +3172,7 @@ dependencies = [
  "sha2 0.11.0",
  "sqlx",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-http",
  "tower-layer",
@@ -4161,16 +3971,6 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
-]
-
-[[package]]
-name = "tinytemplate"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/rullst/Cargo.toml
+++ b/rullst/Cargo.toml
@@ -59,6 +59,10 @@ serde-wasm-bindgen = "0.6"
 console_error_panic_hook = "0.1.7"
 getrandom = { version = "0.2", features = ["js"] }
 
+[dev-dependencies]
+futures-util = "0.3.32"
+tokio-tungstenite = "0.29.0"
+
 
 
 

--- a/rullst/src/queue.rs
+++ b/rullst/src/queue.rs
@@ -806,8 +806,14 @@ mod tests {
         let queue = Queue::sqlite("sqlite::memory:").await.unwrap();
 
         // Dispatch some jobs
-        queue.dispatch("job1", serde_json::json!({"data": 1})).await.unwrap();
-        queue.dispatch("job2", serde_json::json!({"data": 2})).await.unwrap();
+        queue
+            .dispatch("job1", serde_json::json!({"data": 1}))
+            .await
+            .unwrap();
+        queue
+            .dispatch("job2", serde_json::json!({"data": 2}))
+            .await
+            .unwrap();
 
         // List jobs
         let jobs = queue.list_all_jobs(10).await.unwrap();
@@ -824,11 +830,26 @@ mod tests {
 
         #[async_trait]
         impl QueueDriver for ErrorMockDriver {
-            async fn push(&self, _id: &str, _job_name: &str, _payload: &str) -> Result<(), QueueError> { Ok(()) }
-            async fn pop(&self) -> Result<Option<QueuedJob>, QueueError> { Ok(None) }
-            async fn mark_complete(&self, _job_id: &str) -> Result<(), QueueError> { Ok(()) }
-            async fn mark_failed(&self, _job_id: &str, _error: &str) -> Result<(), QueueError> { Ok(()) }
-            async fn pending_count(&self) -> Result<u64, QueueError> { Ok(0) }
+            async fn push(
+                &self,
+                _id: &str,
+                _job_name: &str,
+                _payload: &str,
+            ) -> Result<(), QueueError> {
+                Ok(())
+            }
+            async fn pop(&self) -> Result<Option<QueuedJob>, QueueError> {
+                Ok(None)
+            }
+            async fn mark_complete(&self, _job_id: &str) -> Result<(), QueueError> {
+                Ok(())
+            }
+            async fn mark_failed(&self, _job_id: &str, _error: &str) -> Result<(), QueueError> {
+                Ok(())
+            }
+            async fn pending_count(&self) -> Result<u64, QueueError> {
+                Ok(0)
+            }
             async fn list_all_jobs(&self, _limit: u32) -> Result<Vec<QueuedJobDetail>, QueueError> {
                 Err(QueueError::Driver("simulated db error".into()))
             }

--- a/rullst/src/queue.rs
+++ b/rullst/src/queue.rs
@@ -802,7 +802,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_sqlite_queue_list_all_jobs() {
+    async fn test_sqlite_queue_list_all_jobs_wrapper() {
         let queue = Queue::sqlite("sqlite::memory:").await.unwrap();
 
         // Dispatch some jobs

--- a/rullst/tests/live_tests.rs
+++ b/rullst/tests/live_tests.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
-use axum::{routing::get, Router};
+use axum::{Router, routing::get};
 use futures_util::{SinkExt, StreamExt};
-use rullst::live::{live_ws_handler, Live, LiveComponent};
+use rullst::live::{Live, LiveComponent, live_ws_handler};
 use serde_json::Value;
 use tokio::net::TcpListener;
 use tokio_tungstenite::tungstenite::Message;
@@ -48,7 +48,9 @@ async fn test_live_mount_html() {
 async fn test_live_mount_safe_path() {
     let html = Live::mount::<CounterComponent>("/live?param=\"hack\"&other='<>'").await;
 
-    assert!(html.contains("ws-connect=\"/live?param=&quot;hack&quot;&amp;other=&#x27;&lt;&gt;&#x27;\""));
+    assert!(
+        html.contains("ws-connect=\"/live?param=&quot;hack&quot;&amp;other=&#x27;&lt;&gt;&#x27;\"")
+    );
 }
 
 #[tokio::test]
@@ -95,7 +97,9 @@ async fn test_live_ws_handler() {
     });
 
     ws_stream
-        .send(Message::Text(serde_json::to_string(&event2).unwrap().into()))
+        .send(Message::Text(
+            serde_json::to_string(&event2).unwrap().into(),
+        ))
         .await
         .expect("Failed to send message");
 

--- a/rullst/tests/live_tests.rs
+++ b/rullst/tests/live_tests.rs
@@ -1,0 +1,113 @@
+use async_trait::async_trait;
+use axum::{routing::get, Router};
+use futures_util::{SinkExt, StreamExt};
+use rullst::live::{live_ws_handler, Live, LiveComponent};
+use serde_json::Value;
+use tokio::net::TcpListener;
+use tokio_tungstenite::tungstenite::Message;
+
+// A simple mock component for testing
+#[derive(Default, Clone)]
+struct CounterComponent {
+    count: i32,
+    mounted: bool,
+}
+
+#[async_trait]
+impl LiveComponent for CounterComponent {
+    async fn mount(&mut self) {
+        self.mounted = true;
+        self.count = 10;
+    }
+
+    async fn handle_event(&mut self, payload: Value) {
+        if let Some(action) = payload.get("action").and_then(|v| v.as_str()) {
+            match action {
+                "increment" => self.count += 1,
+                "decrement" => self.count -= 1,
+                _ => {}
+            }
+        }
+    }
+
+    fn render(&self) -> String {
+        format!("<div id=\"counter\">Count: {}</div>", self.count)
+    }
+}
+
+#[tokio::test]
+async fn test_live_mount_html() {
+    let html = Live::mount::<CounterComponent>("/live/counter").await;
+
+    assert!(html.contains("hx-ext=\"ws\""));
+    assert!(html.contains("ws-connect=\"/live/counter\""));
+    assert!(html.contains("<div id=\"counter\">Count: 10</div>"));
+}
+
+#[tokio::test]
+async fn test_live_mount_safe_path() {
+    let html = Live::mount::<CounterComponent>("/live?param=\"hack\"&other='<>'").await;
+
+    assert!(html.contains("ws-connect=\"/live?param=&quot;hack&quot;&amp;other=&#x27;&lt;&gt;&#x27;\""));
+}
+
+#[tokio::test]
+async fn test_live_ws_handler() {
+    // 1. Build an Axum router with the WS handler
+    let app = Router::new().route("/ws", get(live_ws_handler::<CounterComponent>));
+
+    // 2. Start a real server on a random port
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    // 3. Connect via WebSocket client
+    let ws_url = format!("ws://{}/ws", addr);
+    let (mut ws_stream, _) = tokio_tungstenite::connect_async(&ws_url)
+        .await
+        .expect("Failed to connect to WS");
+
+    // 4. Send an increment event
+    let event = serde_json::json!({
+        "action": "increment"
+    });
+
+    ws_stream
+        .send(Message::Text(serde_json::to_string(&event).unwrap().into()))
+        .await
+        .expect("Failed to send message");
+
+    // 5. Receive the updated HTML
+    if let Some(Ok(Message::Text(html_response))) = ws_stream.next().await {
+        let html_string = html_response.to_string();
+        // It started at 10 (mount), we incremented it to 11
+        assert_eq!(html_string, "<div id=\"counter\">Count: 11</div>");
+    } else {
+        panic!("Did not receive text message from server");
+    }
+
+    // 6. Send a decrement event
+    let event2 = serde_json::json!({
+        "action": "decrement"
+    });
+
+    ws_stream
+        .send(Message::Text(serde_json::to_string(&event2).unwrap().into()))
+        .await
+        .expect("Failed to send message");
+
+    // 7. Receive the updated HTML
+    if let Some(Ok(Message::Text(html_response))) = ws_stream.next().await {
+        let html_string = html_response.to_string();
+        // It was 11, we decremented it to 10
+        assert_eq!(html_string, "<div id=\"counter\">Count: 10</div>");
+    } else {
+        panic!("Did not receive text message from server");
+    }
+
+    // 8. Gracefully close
+    ws_stream.close(None).await.unwrap();
+}


### PR DESCRIPTION
🎯 **What:** Added tests for the `live.rs` component handling, which was previously untested. Added dependencies `tokio-tungstenite` and `futures-util` for WebSocket testing.
📊 **Coverage:** Tests now cover mounting components, path safety, and the full WebSocket lifecycle including handling events and sending updated HTML.
✨ **Result:** Improved test coverage for the `rullst::live` module.

---
*PR created automatically by Jules for task [6603759941706340495](https://jules.google.com/task/6603759941706340495) started by @venelouis*