### PR TITLE
fix(security): resolve CSRF memory exhaustion and stabilize cryptogra…

### DIFF
--- a/AUDITORIA.md
+++ b/AUDITORIA.md
@@ -1,0 +1,77 @@
+# Auditoria Completa: Framework Rullst
+
+Este documento contém o relatório de auditoria completa da biblioteca/framework `Rullst`, focado em Segurança, Atualizações de Dependências, Performance, Bugs, UX/DX e Facilidade de Manutenção.
+
+---
+
+## 1. Segurança (Prioridade Alta)
+
+A análise focou nos vetores clássicos de ataque em frameworks web (XSS, CSRF, Injeção, Traversal, etc.).
+
+### 1.1 Proteção contra CSRF
+- **O que foi feito bem**: O `rullst::security::csrf_middleware` implementa o padrão *Double Submit Cookie* e bloqueia corretamente requisições mutáveis (POST/PUT/DELETE) caso o token seja inválido.
+- **Ponto de Atenção Crítico (Corpo de Requisição)**: Para extrair o token do corpo (`extract_token_from_body`), o framework consome e aloca até 1MB do corpo na memória (`axum::body::to_bytes(body, 1024 * 1024)`). Se um atacante enviar milhões de requisições POST com 1MB cada, o servidor rapidamente sofrerá de **Memory Exhaustion (DoS)**. Recomenda-se implementar limites globais (via `tower_http::limit::RequestBodyLimitLayer`) e evitar fazer o buffer inteiro da requisição na memória a menos que estritamente necessário.
+- **Ponto de Atenção Crítico (Verificação Lax)**: Ao gerar um cookie de CSRF em um simples método GET, a implementação atual o marca como `SameSite=Lax`. Em arquiteturas modernas de API, o ideal seria que a geração do token CSRF ficasse restrita a um endpoint específico, e/ou que usasse `SameSite=Strict` para maior segurança.
+
+### 1.2 Proteção contra XSS
+- **O que foi feito bem**: A macro `html!` chama `HtmlEscape::escape_html()` para variáveis dinâmicas injetadas na template. Além disso, o `rullst::security::headers_middleware` injeta o cabeçalho `X-XSS-Protection`.
+- **Atenção**: O tipo `RawHtml` permite injeção arbitrária, o que é esperado do design. O desenvolvedor precisa ser muito bem documentado/avisado para não passar dados de usuários não purificados no `RawHtml(user_input)`.
+
+### 1.3 Path Traversal e Storage
+- **O que foi feito bem**: O `LocalDriver::resolve_path` em `storage.rs` normaliza o caminho e previne de fato ataques básicos de Path Traversal bloqueando a leitura caso a raiz resolvida não inicie com a variável de ambiente `STORAGE_ROOT`.
+- **Atenção**: A construção de diretórios e o parse na stdlib já filtram componentes relativos `..`, mas manter esse driver sempre bem auditado em futuras PRs é vital.
+
+### 1.4 Multitenancy Parameter Leak (Vazamento de Informações)
+- O `TenantStrategy::Parameter` permite o id do lojista (tenant_id) na query string. Conforme o próprio comentário do autor documenta, isso é um vazamento crasso em logs e `Referer`. É recomendado um log em *warning* ou documentar que *Parameter* não deve ser usado em produção.
+
+### 1.5 Dylib Plugin Loader e Execução de Código
+- Em `server.rs`, `load_dylib_router` usa o `libloading` via `unsafe` para carregar routers alocados num plugin.
+- **Risco de Segurança**: Carregar código dinâmico local exige confiança extrema no sistema de arquivos local do host. Em ambientes containerizados com permissões frouxas, um atacante com *File Write Access* pode injetar sua própria `.so` e tomar o controle de todo o processo Rust via uma `rullst_router_init` maliciosa (RCE).
+- **Mitigação**: Os arquivos carregáveis devem verificar assinaturas criptográficas ou o diretório alvo da extensão deve ser `chmod 400` pelo sistema operacional.
+
+---
+
+## 2. Atualização e Dependências
+
+A simulação de atualização revelou que o projeto usa um lockfile mas que algumas bibliotecas core estão recebendo releases constantes (embora mantidas em compatibilidade semver pela flag `--dry-run`).
+
+- **Dependências de Infraestrutura AWS**: `aws-sdk-s3`, `aws-config`, `aws-sdk-sso`, etc. possuem pequenas bumps de versão constantes. Recomenda-se um Dependabot.
+- **Dependências Críticas**: O framework prende (pin) versões de `argon2` e `aes-gcm` nas branches `Release Candidate (rc)`. Ex: `"0.11.0-rc.4"`, `"0.6.0-rc.8"`.
+  - **Ação**: Isso é um risco de quebra e instabilidade. Assim que a versão final dessas bibliotecas de criptografia for lançada, o framework deve transacionar para elas.
+
+---
+
+## 3. Performance e Concorrência
+
+- **Construtores de Query / Strings em Laços**: A documentação já instrui o uso de `String::with_capacity` e `write!` para HTML. A macro `rullst-macros` compila o HTML de maneira bastante performante (no-runtime parsing).
+- **Zstd / Brotli (cargo-rullst/src/main.rs)**: Há um script no cargo-rullst que comprime ativos estáticos no build para Brotli e ZSTD. Ótimo padrão de performance (Pré-compressão).
+- **Replication Manager Sleep Tick**: No `db.rs`, a versão WASM usa uma trava por *spinlock* (`while ticks < config.sync_interval_secs ...`). Isso gasta ciclos inúteis do Event Loop no Web Worker. O ideal seria usar o `setTimeout` exportado pelo `web_sys` via Promessas (Promise-based sleep) ao invés do `performance.now()`.
+
+---
+
+## 4. Bugs e Tratamento de Erros
+
+- No `server.rs`, o catch de panic é tratado, mas a transformação do Downcast do `JoinError` assume que pânicos são strings puras (`&str` ou `String`). Objetos arbitrários em *panic!* gerarão a mensagem genérica.
+- **Mail Driver Resend**: Em `mail.rs`, caso a API da Resend retorne um erro HTML (como erro de Gateway/Cloudflare do lado deles), a conversão de `res.text().await` trará uma página HTML massiva no payload do log de erro da aplicação, sujando imensamente os logs locais do container de produção.
+
+---
+
+## 5. Experiência do Desenvolvedor (DX) e UX
+
+- **DX Extremamente Alto**: A inclusão do *Artisan* embutido (inspirado no Laravel), suporte forte à HTMX no `htmx.rs`, macros baseados em JSX, suporte multi-tenant transparente via Traits de camada, e Wasm-Islands marcam uma usabilidade formidável para desenvolvedores.
+- **Consoles interativos**: O Rullst Studio e as tratativas do *Error Console HTML* são grandes pontos extras.
+- **Documentação de Testes**: A adoção de `mod tests` in-file facilita absurdamente a busca de comportamento interno pelos contribuidores.
+- **Falta de Tipagem Estrita em Rotas HTMX**: `HtmxResponse` permite disparar e redirecionar strings de maneira arbitrária (`into()`). A longo prazo, desenvolvedores poderiam achar melhor passar construtores de URL tipados.
+
+---
+
+## 6. Facilidade de Manutenção (Maintainability)
+
+- O projeto usa uma estrutura baseada em *Features* no `Cargo.toml`. Essa é uma técnica arquitetural de alto nível para não inflar as dependências com `redis`, `s3`, e `lettre` se o usuário quer apenas a API base.
+- **Modularização**: Cada componente do framework tem seu arquivo restrito (ex. `queue.rs`, `storage.rs`, `db.rs`, `mail.rs`). O design pattern *Facade* está presente em todo lado (ex. `Storage::put()`, `Queue::sqlite()`).
+- O suporte a `Box<dyn Driver>` permite TDD fluído e fácil substituição de comportamentos, fazendo com que a manutenção e os mocks no código do usuário final seja livre de dores de cabeça.
+
+---
+
+## Conclusão e Próximos Passos
+O framework `rullst` se apresenta extremamente moderno, absorvendo boas práticas de ponta de Rust e ecossistemas Fullstack. A principal ação recomendada é rever os pontos de gargalo de alocação de memória nos middlewares de Segurança (o buffer do corpo na verificação do CSRF) e atualizar dependências de criptografia de `rc` para versões estáveis quando lançadas.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,30 +4,30 @@ version = 4
 
 [[package]]
 name = "aead"
-version = "0.6.0-rc.10"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b657e772794c6b04730ea897b66a058ccd866c16d1967da05eeeecec39043fe"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common 0.2.2",
- "inout",
+ "crypto-common 0.1.6",
+ "generic-array",
 ]
 
 [[package]]
 name = "aes"
-version = "0.9.1"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
+ "cfg-if",
  "cipher",
- "cpubits",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.11.0-rc.4"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da8c919c118108f144adecad74b425b804ad075580d605d9b33c2d6d1c62a2f8"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
  "aes",
@@ -140,13 +140,13 @@ checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
 
 [[package]]
 name = "argon2"
-version = "0.6.0-rc.8"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7af50940b73bf4e16c15c448a2b121c63f2d68e3e54b6a8731673cb4aa0cdff5"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -768,11 +768,11 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.11.0-rc.6"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest 0.11.3",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -913,12 +913,11 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "block-buffer 0.12.0",
- "crypto-common 0.2.2",
+ "crypto-common 0.1.6",
  "inout",
 ]
 
@@ -1077,12 +1076,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "cpubits"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1180,6 +1173,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1189,16 +1183,14 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "getrandom 0.4.2",
  "hybrid-array",
- "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "ctr"
-version = "0.10.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
 ]
@@ -1688,10 +1680,11 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.6.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
+ "opaque-debug",
  "polyval",
 ]
 
@@ -2184,11 +2177,11 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.2.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "hybrid-array",
+ "generic-array",
 ]
 
 [[package]]
@@ -2557,6 +2550,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2611,12 +2610,13 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.6.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aab41826031698d6ffcd9cff78ef56ef998e39dc7e5067cdfebe373842d4723b"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
- "getrandom 0.4.2",
- "phc",
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -2633,17 +2633,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "phc"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44dc769b75f93afdddd8c7fa12d685292ddeff1e66f7f0f3a234cf1818afe892"
-dependencies = [
- "base64ct",
- "ctutils",
- "getrandom 0.4.2",
-]
 
 [[package]]
 name = "phf"
@@ -2717,12 +2706,13 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polyval"
-version = "0.7.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
- "cpubits",
- "cpufeatures 0.3.0",
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
  "universal-hash",
 ]
 
@@ -3120,6 +3110,7 @@ dependencies = [
  "libloading",
  "notify",
  "rand 0.10.1",
+ "rand_core 0.6.4",
  "redis",
  "reqwest",
  "ring",
@@ -4221,12 +4212,12 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
-version = "0.6.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common 0.2.2",
- "ctutils",
+ "crypto-common 0.1.6",
+ "subtle",
 ]
 
 [[package]]

--- a/rullst/Cargo.toml
+++ b/rullst/Cargo.toml
@@ -33,10 +33,11 @@ tower-http = { version = "0.6.11", features = ["fs", "trace"] }
 tower-layer = "0.3.3"
 tower-service = "0.3.3"
 async-trait = "0.1.89"
-argon2 = "0.6.0-rc.8"
+argon2 = "0.5.3"
 cookie = { version = "0.18.1", features = ["percent-encoding"] }
 rand = "0.10.1"
-aes-gcm = "0.11.0-rc.4"
+rand_core = { version = "0.6.4", features = ["std"] }
+aes-gcm = "0.10.3"
 sha2 = "0.11.0"
 base64 = "0.22.1"
 serde_urlencoded = "0.7"

--- a/rullst/src/auth.rs
+++ b/rullst/src/auth.rs
@@ -4,8 +4,9 @@ use aes_gcm::{
 };
 use argon2::{
     Argon2,
-    password_hash::{PasswordHasher, PasswordVerifier, phc::PasswordHash},
+    password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
 };
+use rand_core::OsRng;
 use axum::http::HeaderMap;
 use base64::{Engine as _, engine::general_purpose};
 use sha2::Digest;
@@ -20,9 +21,10 @@ static DEV_APP_KEY: OnceLock<Vec<u8>> = OnceLock::new();
 
 /// Hashes a plain-text password using Argon2id with a cryptographically secure random salt.
 pub fn hash_password(password: &str) -> Result<String, String> {
+    let salt = SaltString::generate(&mut OsRng);
     let argon2 = Argon2::default();
     argon2
-        .hash_password(password.as_bytes())
+        .hash_password(password.as_bytes(), &salt)
         .map(|h| h.to_string())
         .map_err(|e| e.to_string())
 }

--- a/rullst/src/security.rs
+++ b/rullst/src/security.rs
@@ -42,9 +42,9 @@ pub async fn csrf_middleware(req: Request, next: Next) -> Response {
             let token = generate_csrf_token();
             let mut response = next.run(req).await;
 
-            // Set cookie for Lax mode
+            // Set cookie for Strict mode
             if let Ok(cookie_val) = header::HeaderValue::from_str(&format!(
-                "rullst_csrf={}; Path=/; SameSite=Lax; HttpOnly",
+                "rullst_csrf={}; Path=/; SameSite=Strict; HttpOnly",
                 token
             )) {
                 response
@@ -90,24 +90,32 @@ pub async fn csrf_middleware(req: Request, next: Next) -> Response {
         return (StatusCode::FORBIDDEN, "Invalid CSRF token").into_response();
     }
 
-    // If not in header, read urlencoded body
-    let (parts, body) = req.into_parts();
+    // If not in header, check if it's a form-urlencoded request before buffering the body
+    let content_type = req
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
 
-    // Read request body (limited to 1MB to prevent memory exhaustion)
-    let bytes = match axum::body::to_bytes(body, 1024 * 1024).await {
-        Ok(b) => b,
-        Err(_) => return (StatusCode::BAD_REQUEST, "Failed to read request body").into_response(),
-    };
+    if content_type.contains("application/x-www-form-urlencoded") {
+        let (parts, body) = req.into_parts();
 
-    let body_token = extract_token_from_body(&bytes);
+        // Read request body (limited to 1MB to prevent memory exhaustion)
+        let bytes = match axum::body::to_bytes(body, 1024 * 1024).await {
+            Ok(b) => b,
+            Err(_) => return (StatusCode::BAD_REQUEST, "Failed to read request body").into_response(),
+        };
 
-    // Reconstruct the request so it can be parsed by subsequent handlers
-    let reconstructed_req = Request::from_parts(parts, axum::body::Body::from(bytes));
+        let body_token = extract_token_from_body(&bytes);
 
-    if let Some(token) = body_token
-        && token == cookie_token
-    {
-        return next.run(reconstructed_req).await;
+        // Reconstruct the request so it can be parsed by subsequent handlers
+        let reconstructed_req = Request::from_parts(parts, axum::body::Body::from(bytes));
+
+        if let Some(token) = body_token
+            && token == cookie_token
+        {
+            return next.run(reconstructed_req).await;
+        }
     }
 
     (StatusCode::FORBIDDEN, "Invalid or missing CSRF token").into_response()


### PR DESCRIPTION
…phy deps

- Refactored CSRF middleware to only parse request body as bytes if the Content-Type header indicates `application/x-www-form-urlencoded`. This mitigates memory exhaustion risks from large irrelevant payloads.
- Upgraded the CSRF cookie's SameSite attribute from `Lax` to `Strict` for enhanced cross-site protection.
- Downgraded `argon2` and `aes-gcm` dependencies from unstable release candidates (`-rc`) to their latest stable versions (`0.5.3` and `0.10.3` respectively), adjusting the `hash_password` implementation to explicitly generate and pass salts. Added `rand_core` to facilitate this.