### PR TITLE
docs: Adiciona relatório completo de auditoria (jules.md)

### DIFF
--- a/jules.md
+++ b/jules.md
@@ -1,0 +1,34 @@
+# Relatório de Auditoria Completa do Rullst
+
+Este documento apresenta os resultados da auditoria de segurança, qualidade de código, formatação, performance e arquitetura, executada sobre o workspace Rullst.
+
+## 1. Auditoria de Segurança (Dependências)
+Foi executada a ferramenta `cargo-audit` em todo o workspace (`cargo audit`).
+- **Vulnerabilidades Graves (CVEs):** Nenhuma vulnerabilidade de segurança conhecida foi encontrada no código ou nas dependências atuais.
+- **Avisos:** Foi identificado 1 aviso referente à manutenção de pacotes:
+  - O crate `proc-macro-error2` (versão 2.0.1) está marcado como não-mantido (unmaintained). Ele foi reportado pela RUSTSEC-2026-0173.
+
+*Recomendação:* Considere buscar alternativas modernas para o `proc-macro-error2` a fim de evitar problemas futuros de compatibilidade e segurança.
+
+## 2. Auditoria de Qualidade e Formatação de Código
+As ferramentas nativas do ecossistema Rust foram utilizadas para avaliar a qualidade e a padronização do código-fonte.
+- **`cargo clippy`**: A verificação com `cargo clippy --workspace --all-targets --all-features` foi concluída sem retornar nenhum aviso ou erro. Isso indica que a base de código está escrita seguindo fortes práticas idiomáticas da linguagem Rust.
+- **`cargo fmt`**: O comando `cargo fmt --all -- --check` não encontrou divergências de estilo, comprovando que as regras de formatação do projeto estão sendo estritamente seguidas pela equipe.
+
+## 3. Auditoria de Performance e Arquitetura (Análise Estrutural)
+Com base nas diretrizes do projeto Rullst (`AGENTS.md` e memórias internas), uma análise estática e baseada em texto foi conduzida para assegurar que a arquitetura siga as melhores práticas.
+- **Prevenção contra SQL Injection e Concatenação Ineficiente:**
+  Não foram detectados usos diretos do macro `format!` em conjunção com `sqlx` (o que seria uma quebra das regras de segurança anti-injeção). Além disso, o código evita padrões prejudiciais como `push_str(format!(...))`.
+- **Blocos `unsafe`:**
+  A verificação de blocos `unsafe` retornou um número bem definido e justificado de ocorrências. O uso de código inseguro se concentra na camada de carregamento dinâmico e FFI (em `rullst/src/server.rs` com a API do `libloading`) e nas exportações sem mangling (`#[unsafe(no_mangle)]`) de blueprints gerados pelo `cargo-rullst`. O uso do `unsafe` se mantém contido e adere às diretrizes para carregamento de biblioteca dinâmica do framework.
+- **Débito Técnico e Documentação (TODOs):**
+  Identificou-se uma grande quantidade de avisos de `/// [TODO] Missing documentation.` dentro do código-fonte, principalmente em componentes sensíveis. Eles se concentram nos seguintes módulos:
+  - `rullst/src/ai/mod.rs` e sub-módulos.
+  - `rullst/src/auth/passkey.rs`
+  - `rullst/src/storage.rs`
+  - `rullst/src/lib.rs` e `rullst/src/server.rs`
+
+*Recomendação:* Adicionar docstrings ricas detalhando o propósito, os parâmetros esperados e potenciais pânicos (quando apropriado) para os módulos assinalados com falta de documentação. A ausência de regras estritas falhando na esteira de CI por falta de documentação não reduz a importância dessas descrições para a comunidade e o ecossistema Rullst.
+
+## 4. Conclusão
+A auditoria constatou que o Rullst e seus sub-crates mantêm altíssimos padrões de qualidade de engenharia e segurança. O código passa limpo pelos linters rigorosos de Rust. Os pontos de melhoria são de manutenção e arquitetura de longo prazo (substituição de uma dependência órfã) e débito de documentação, mas a estabilidade e segurança estrutural do projeto estão excelentes.


### PR DESCRIPTION
Este PR introduz um relatório detalhado (`jules.md`) que sumariza uma auditoria completa conduzida no workspace Rullst.

Foram abordados pontos sobre segurança (uso do `cargo-audit`), qualidade/estilo de código (com o `clippy` e `fmt`), segurança arquitetural e identificação de falta de documentação em módulos cruciais do framework. Nenhuma alteração foi feita no código-fonte em si.

---
*PR created automatically by Jules for task [10118497637307913514](https://jules.google.com/task/10118497637307913514) started by @venelouis*